### PR TITLE
Adds `pathlib` support for building directory tree filestring paths

### DIFF
--- a/tools/fileio_interface.py
+++ b/tools/fileio_interface.py
@@ -13,6 +13,10 @@ Description
 Functions
 ---------
 
+    build_path(path_list)
+
+        This function builds and returns a directory tree path.
+
     chdir(path)
 
         This function execute task calls within the specified datapath
@@ -124,6 +128,7 @@ History
 import os
 import shutil
 from contextlib import contextmanager
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import List, Tuple
 
@@ -134,6 +139,7 @@ from utils.logger_interface import Logger
 
 # Define all available module properties.
 __all__ = [
+    "build_path",
     "chdir",
     "concatenate",
     "copyfile",
@@ -154,6 +160,39 @@ __all__ = [
 # ----
 
 logger = Logger(caller_name=__name__)
+
+# ----
+
+
+def build_path(path_list: List) -> str:
+    """
+    Description
+    -----------
+
+    This function builds and returns a directory tree path.
+
+    Parameters
+    ----------
+
+    path_list: ``List``
+
+        A Python ordered list containing the directory tree path
+        string(s).
+
+    Returns
+    -------
+
+    path: ``str``
+
+        A Python string containing the directory tree path.
+
+    """
+
+    # Build the directory tree path.
+    path = str(Path(*path_list))
+
+    return path
+
 
 # ----
 


### PR DESCRIPTION
# Description

This PR addresses issue #2. The following is accomplished:

- the `pathlib` package is used to build directory tree file path strings;
- function `build_path` is added to the `fileio_interface` module.

  Resolves #2 

# Type of change

- New feature (adds functionality)

# Change characteristics
- Is this a breaking change (a change in existing functionality)? NO
- Does this change require a documentation update? NO

# How has this been tested?

# Checklist
- [x] Any dependent changes have been merged and published
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] New and existing tests pass with my changes
- [ ] I have made corresponding changes to the documentation if necessary
